### PR TITLE
speech.jsに一時停止・再開機能を追加

### DIFF
--- a/speech.js
+++ b/speech.js
@@ -21,7 +21,7 @@
     button.className = 'btn';
     button.textContent = '音読する';
     button.style = 'float: right';
-    article.querySelector('header').appendChild(button);
+    article.querySelector('header.entry').appendChild(button);
     button.addEventListener('click', function () {
       var synth = window.speechSynthesis;
       var body = article.querySelector('.entry-content').textContent;

--- a/speech.js
+++ b/speech.js
@@ -15,6 +15,11 @@
 
 function speak (e) {
   speechSynthesis.cancel();
+
+  // Chromeで初回実行時にspeechSynthesis.pause()できない問題を解消するため、空文字で一度speechSynthesis.speak()しておく
+  var empty_utter = new SpeechSynthesisUtterance('');
+  speechSynthesis.speak(empty_utter);
+
   var utter = new SpeechSynthesisUtterance(this.body);
   speechSynthesis.speak(utter);
   e.currentTarget.textContent = '停止する';

--- a/speech.js
+++ b/speech.js
@@ -13,20 +13,39 @@
 
 */
 
+function speak (e) {
+  speechSynthesis.cancel();
+  var utter = new SpeechSynthesisUtterance(this.body);
+  speechSynthesis.speak(utter);
+  e.currentTarget.textContent = '停止する';
+  e.currentTarget.removeEventListener('click', this);
+  e.currentTarget.addEventListener('click', pause);
+}
+
+function pause (e) {
+  speechSynthesis.pause();
+  e.currentTarget.textContent = '再開する';
+  e.currentTarget.removeEventListener('click', pause);
+  e.currentTarget.addEventListener('click', resume);
+}
+
+function resume (e) {
+  speechSynthesis.resume();
+  e.currentTarget.textContent = '停止する';
+  e.currentTarget.removeEventListener('click', resume);
+  e.currentTarget.addEventListener('click', pause);
+}
+
 (function () {
   if (!window.speechSynthesis) return;
-  document.querySelectorAll('article').forEach(function (article) {
+  document.querySelectorAll('article.entry').forEach(function (article) {
     var button = document.createElement('button');
     button.type = 'button';
     button.className = 'btn';
     button.textContent = '音読する';
     button.style = 'float: right';
-    article.querySelector('header.entry').appendChild(button);
-    button.addEventListener('click', function () {
-      var synth = window.speechSynthesis;
-      var body = article.querySelector('.entry-content').textContent;
-      var utter = new SpeechSynthesisUtterance(body);
-      synth.speak(utter);
-    });
+    article.querySelector('header').appendChild(button);
+    var body = article.querySelector('.entry-content').textContent;
+    button.addEventListener('click', { handleEvent: speak, body: body });
   });
 })();


### PR DESCRIPTION
# speech.jsに一時停止・再開機能を追加

https://blog.sushi.money/entry/2017/12/11/191629

3年前の記事ですが、「音読する」ボタンに一時停止・再開機能を追加してみました。

## 動作確認

https://fuyu77.github.io/hatenablog-unofficial-modules/speech.js

こちらのURLにアップしてあります。

https://fuyu.hatenablog.com

こちらの私のブログにも設置してあります。

## Chromeで初回実行時にspeechSynthesis.pause()できない問題

https://github.com/hitode909/hatenablog-unofficial-modules/commit/ab228f456cf926864e368aa7c5c40a4ffc805eee

Google Chromeアプリ再起動後の初回の実行で `speechSynthesis.pause()` が実行されない問題がありました。

https://stackoverflow.com/questions/53101113/speech-synthesis-wont-pause-in-google-chrome-at-first-load-after-browser-launch

上掲のStackOverflowの方法で解消したのですが、詳細な原因を特定できていません。